### PR TITLE
Magazine管理画面にて、選択した画像をプレビュー & 保存リクエストを送信

### DIFF
--- a/src/app/(auth)/magazine/PageBody.tsx
+++ b/src/app/(auth)/magazine/PageBody.tsx
@@ -268,16 +268,39 @@ export default function PageBody() {
                       />
                     </TableCell>
                     <TableCell className="p-2">
-                      <File
-                        name={`articles.${i}.thumbnail`}
-                        accept="image/*"
-                        buttonClass="text-nowrap rounded-md border border-[var(--myturn-sub-text)] bg-[var(--myturn-background)] px-2 py-1 text-sm"
-                        onChangeFiles={({ file }) =>
-                          changeOneOfThumbnail(article.articleId, file)
-                        }
-                      >
-                        ファイルを選択
-                      </File>
+                      <Box>
+                        <File
+                          name={`articles.${i}.thumbnail`}
+                          accept="image/*"
+                          buttonClass="text-nowrap rounded-md border border-[var(--myturn-sub-text)] bg-[var(--myturn-background)] px-2 py-1 text-sm"
+                          onChangeFiles={({ file }) =>
+                            changeOneOfThumbnail(article.articleId, file)
+                          }
+                        >
+                          ファイルを選択
+                        </File>
+                        {/* 入力画像のプレビュー */}
+                        {thumbnails[article.articleId] && (
+                          <Box className="mt-2 max-w-40">
+                            <img
+                              src={thumbnails[article.articleId].dataUrl}
+                              alt="記事のサムネイル"
+                              className="w-full object-contain"
+                            />
+                          </Box>
+                        )}
+                        {/* 保存済み画像の表示 */}
+                        {!thumbnails[article.articleId] &&
+                          thumbnailSrcs[article.articleId] && (
+                            <Box className="mt-2 max-w-40">
+                              <img
+                                src={thumbnailSrcs[article.articleId]}
+                                alt="記事のサムネイル"
+                                className="w-full object-contain"
+                              />
+                            </Box>
+                          )}
+                      </Box>
                     </TableCell>
                     <TableCell className="p-2 pr-4">
                       <TextField

--- a/src/app/(auth)/magazine/PageBody.tsx
+++ b/src/app/(auth)/magazine/PageBody.tsx
@@ -1,15 +1,13 @@
 "use client";
 import { useState } from "react";
-import {
-  DefaultValues,
-  FormProvider,
-  useFieldArray,
-  useForm,
-} from "react-hook-form";
+import { FormProvider, useFieldArray, useForm } from "react-hook-form";
+import { useMutation, useQuery } from "@apollo/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  Alert,
   Box,
   Button,
+  Snackbar,
   Table,
   TableBody,
   TableCell,
@@ -17,42 +15,191 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
+import { MagazineType } from "@/graphql-client";
 import {
   MagazineEditFormData,
   magazineEditFormSchema,
 } from "@/schemas/magazine/edit";
+import { UPDATE_MAGAZINE } from "@/server/graphql/magazine/mutations";
+import { GET_MAGAZINE } from "@/server/graphql/magazine/query";
+import { blobToDataUrl } from "@/utils/frontend/file";
 import PageTitle from "@/components/common/PageTitle";
 import TextField from "@/components/common/form/TextField";
 import File from "@/components/common/form/File";
 
+type EditingMagazineItem = {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  articleUrl: string;
+  thumbnailUrl: string;
+  thumbnailBase64: string;
+  thumbnailMimeType: string;
+};
+
 export default function PageBody() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const initForm: DefaultValues<MagazineEditFormData> = {
-    articles: new Array(5).fill(null).map(() => ({
+  // 取得した保存済みサムネイル画像のURL
+  const [thumbnailSrcs, setThumbnailSrcs] = useState<Record<number, string>>(
+    {},
+  );
+  // 入力中のサムネイル画像
+  const [thumbnails, setThumbnails] = useState<
+    Record<number, { dataUrl: string; type: string }>
+  >({});
+
+  // トースト通知の状態
+  const [toast, setToast] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error" | "info" | "warning";
+  }>({
+    open: false,
+    message: "",
+    severity: "info",
+  });
+
+  // トースト通知を閉じる
+  const handleCloseToast = () => {
+    setToast({ ...toast, open: false });
+  };
+
+  // トースト通知を表示
+  const showToast = (
+    message: string,
+    severity: "success" | "error" | "info" | "warning",
+  ) => {
+    setToast({
+      open: true,
+      message,
+      severity,
+    });
+  };
+
+  // Magazineデータ更新
+  const [updateArticles, { loading: isUpdating }] = useMutation(
+    UPDATE_MAGAZINE,
+    {
+      onCompleted: () => {
+        // 更新成功時のトースト表示
+        showToast("記事情報が更新されました", "success");
+      },
+      onError: (error) => {
+        console.error("更新中にエラーが発生しました:", error);
+        setError(error.message || "更新中にエラーが発生しました");
+        // エラー時のトースト表示
+        showToast("更新中にエラーが発生しました", "error");
+      },
+    },
+  );
+
+  const initFormArticles: MagazineEditFormData["articles"] = new Array(5)
+    .fill(null)
+    .map((article, i) => ({
+      articleId: i + 1,
       title: "",
       description: "",
       category: "",
       thumbnail: null,
-      url: "",
-    })),
-  };
+      articleUrl: "",
+    }));
   const methods = useForm<MagazineEditFormData>({
     resolver: zodResolver(magazineEditFormSchema),
     mode: "onChange", // リアルタイムバリデーション
-    defaultValues: initForm,
+    defaultValues: { articles: initFormArticles },
   });
   const articlesControl = useFieldArray({
     control: methods.control,
     name: "articles",
   });
 
-  const onSubmit = async () => {
-    setIsSubmitting(true);
+  // Magazineデータ取得
+  useQuery(GET_MAGAZINE, {
+    fetchPolicy: "network-only",
+    onCompleted: (data) => {
+      const fetchedMagazine: Pick<
+        MagazineType,
+        | "id"
+        | "title"
+        | "description"
+        | "category"
+        | "thumbnailUrl"
+        | "articleUrl"
+      >[] = data.magazines;
+      const initThumbnailSrcs: Record<number, string> = {};
+      fetchedMagazine.forEach((article) => {
+        initThumbnailSrcs[article.id] = article.thumbnailUrl;
+      });
+      setThumbnailSrcs(initThumbnailSrcs);
+
+      const articles = fetchedMagazine.map((item) => ({
+        articleId: item.id,
+        title: item.title,
+        description: item.description,
+        category: item.category,
+        thumbnail: null,
+        articleUrl: item.articleUrl,
+      }));
+      initFormArticles.splice(0, articles.length, ...articles);
+      methods.setValue("articles", initFormArticles);
+    },
+  });
+
+  const changeOneOfThumbnail = async (articleId: number, file: File | null) => {
+    const editingThumbnails = { ...thumbnails };
+    if (file) {
+      editingThumbnails[articleId] = {
+        dataUrl: await blobToDataUrl(file),
+        type: file.type,
+      };
+      setThumbnails(editingThumbnails);
+    } else {
+      delete editingThumbnails[articleId];
+      setThumbnails(editingThumbnails);
+    }
+  };
+
+  // フォームデータをGraphQLミューテーションの入力形式に変換する関数
+  const convertFormDataToUpdateInput = async (data: MagazineEditFormData) => {
+    // 記事情報の処理
+    const articlesInput = await Promise.all(
+      data.articles.map(async (article) => {
+        const articleData: EditingMagazineItem = {
+          id: article.articleId,
+          title: article.title,
+          description: article.description,
+          category: article.category,
+          articleUrl: article.articleUrl,
+          thumbnailUrl: thumbnailSrcs[article.articleId] ?? "",
+          thumbnailBase64: "",
+          thumbnailMimeType: "",
+        };
+
+        const thumbnail = thumbnails[article.articleId];
+        if (thumbnail) {
+          // data:image/jpeg;base64, の部分を削除
+          articleData.thumbnailBase64 = thumbnail.dataUrl.split(",")[1];
+          articleData.thumbnailMimeType = thumbnail.type;
+        }
+
+        return articleData;
+      }),
+    );
+
+    // 更新用の入力データを作成
+    return { magazines: articlesInput };
+  };
+
+  const onSubmit = async (data: MagazineEditFormData) => {
     try {
-      // @todo フォームデータをGraphQLミューテーションの入力形式に変換
-      // @todo ジョブ更新ミューテーションを実行
+      // フォームデータをGraphQLミューテーションの入力形式に変換
+      const updateInput = await convertFormDataToUpdateInput(data);
+      // 更新ミューテーションを実行
+      await updateArticles({
+        variables: { input: updateInput },
+      });
 
       setError(null);
     } catch (err) {
@@ -62,8 +209,6 @@ export default function PageBody() {
           ? err.message
           : "Magazine更新中にエラーが発生しました",
       );
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -96,6 +241,11 @@ export default function PageBody() {
                   >
                     <TableCell className="p-2 pl-4">{i + 1}</TableCell>
                     <TableCell className="p-2">
+                      <input
+                        type="hidden"
+                        name={`articles.${i}.articleId`}
+                        value={article.articleId}
+                      />
                       <TextField
                         name={`articles.${i}.title`}
                         className="w-72"
@@ -122,6 +272,9 @@ export default function PageBody() {
                         name={`articles.${i}.thumbnail`}
                         accept="image/*"
                         buttonClass="text-nowrap rounded-md border border-[var(--myturn-sub-text)] bg-[var(--myturn-background)] px-2 py-1 text-sm"
+                        onChangeFiles={({ file }) =>
+                          changeOneOfThumbnail(article.articleId, file)
+                        }
                       >
                         ファイルを選択
                       </File>
@@ -129,7 +282,7 @@ export default function PageBody() {
                     <TableCell className="p-2 pr-4">
                       <TextField
                         type="url"
-                        name={`articles.${i}.url`}
+                        name={`articles.${i}.articleUrl`}
                         className="w-48"
                         inputClass="valid:border-[var(--myturn-support-middle)]"
                       />
@@ -148,10 +301,26 @@ export default function PageBody() {
             type="submit"
             className="rounded-full bg-[var(--myturn-main)] px-4 py-3 text-[var(--foreground)]"
           >
-            {isSubmitting ? "更新中..." : "更新する"}
+            {isUpdating ? "更新中..." : "更新する"}
           </Button>
         </form>
       </FormProvider>
+
+      {/* トースト通知 */}
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={6000}
+        onClose={handleCloseToast}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          onClose={handleCloseToast}
+          severity={toast.severity}
+          sx={{ width: "100%" }}
+        >
+          {toast.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/src/graphql-client.ts
+++ b/src/graphql-client.ts
@@ -627,7 +627,9 @@ export type MagazineItemInput = {
   articleUrl: Scalars['String']['input'];
   category: Scalars['String']['input'];
   description: Scalars['String']['input'];
-  id?: InputMaybe<Scalars['Int']['input']>;
+  id: Scalars['Int']['input'];
+  thumbnailBase64?: InputMaybe<Scalars['String']['input']>;
+  thumbnailMimeType?: InputMaybe<Scalars['String']['input']>;
   thumbnailUrl: Scalars['String']['input'];
   title: Scalars['String']['input'];
 };
@@ -1514,6 +1516,18 @@ export type GetJobsStatisticsQueryVariables = Exact<{
 
 export type GetJobsStatisticsQuery = { __typename?: 'Query', getJobsStatistics: { __typename?: 'JobsStatisticsResultType', totalCount: number, newPostedCount: number, activeCount: number, closedCount: number } };
 
+export type UpdateMagazineMutationVariables = Exact<{
+  input: UpdateMagazinesInput;
+}>;
+
+
+export type UpdateMagazineMutation = { __typename?: 'Mutation', updateMagazines: Array<{ __typename?: 'MagazineType', id: number, title: string, description: string, category: string, thumbnailUrl: string, articleUrl: string }> };
+
+export type GetMagazineQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMagazineQuery = { __typename?: 'Query', magazines: Array<{ __typename?: 'MagazineType', id: number, title: string, description: string, category: string, thumbnailUrl: string, articleUrl: string }> };
+
 export type SearchUsersQueryVariables = Exact<{
   input: SearchUsersInput;
 }>;
@@ -1730,6 +1744,88 @@ export type GetJobsStatisticsQueryHookResult = ReturnType<typeof useGetJobsStati
 export type GetJobsStatisticsLazyQueryHookResult = ReturnType<typeof useGetJobsStatisticsLazyQuery>;
 export type GetJobsStatisticsSuspenseQueryHookResult = ReturnType<typeof useGetJobsStatisticsSuspenseQuery>;
 export type GetJobsStatisticsQueryResult = Apollo.QueryResult<GetJobsStatisticsQuery, GetJobsStatisticsQueryVariables>;
+export const UpdateMagazineDocument = gql`
+    mutation UpdateMagazine($input: UpdateMagazinesInput!) {
+  updateMagazines(input: $input) {
+    id
+    title
+    description
+    category
+    thumbnailUrl
+    articleUrl
+  }
+}
+    `;
+export type UpdateMagazineMutationFn = Apollo.MutationFunction<UpdateMagazineMutation, UpdateMagazineMutationVariables>;
+
+/**
+ * __useUpdateMagazineMutation__
+ *
+ * To run a mutation, you first call `useUpdateMagazineMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateMagazineMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateMagazineMutation, { data, loading, error }] = useUpdateMagazineMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateMagazineMutation(baseOptions?: Apollo.MutationHookOptions<UpdateMagazineMutation, UpdateMagazineMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateMagazineMutation, UpdateMagazineMutationVariables>(UpdateMagazineDocument, options);
+      }
+export type UpdateMagazineMutationHookResult = ReturnType<typeof useUpdateMagazineMutation>;
+export type UpdateMagazineMutationResult = Apollo.MutationResult<UpdateMagazineMutation>;
+export type UpdateMagazineMutationOptions = Apollo.BaseMutationOptions<UpdateMagazineMutation, UpdateMagazineMutationVariables>;
+export const GetMagazineDocument = gql`
+    query GetMagazine {
+  magazines {
+    id
+    title
+    description
+    category
+    thumbnailUrl
+    articleUrl
+  }
+}
+    `;
+
+/**
+ * __useGetMagazineQuery__
+ *
+ * To run a query within a React component, call `useGetMagazineQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetMagazineQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetMagazineQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetMagazineQuery(baseOptions?: Apollo.QueryHookOptions<GetMagazineQuery, GetMagazineQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetMagazineQuery, GetMagazineQueryVariables>(GetMagazineDocument, options);
+      }
+export function useGetMagazineLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetMagazineQuery, GetMagazineQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetMagazineQuery, GetMagazineQueryVariables>(GetMagazineDocument, options);
+        }
+export function useGetMagazineSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetMagazineQuery, GetMagazineQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetMagazineQuery, GetMagazineQueryVariables>(GetMagazineDocument, options);
+        }
+export type GetMagazineQueryHookResult = ReturnType<typeof useGetMagazineQuery>;
+export type GetMagazineLazyQueryHookResult = ReturnType<typeof useGetMagazineLazyQuery>;
+export type GetMagazineSuspenseQueryHookResult = ReturnType<typeof useGetMagazineSuspenseQuery>;
+export type GetMagazineQueryResult = Apollo.QueryResult<GetMagazineQuery, GetMagazineQueryVariables>;
 export const SearchUsersDocument = gql`
     query SearchUsers($input: SearchUsersInput!) {
   searchUsers(input: $input) {

--- a/src/hooks/useJobsStatistics.ts
+++ b/src/hooks/useJobsStatistics.ts
@@ -21,7 +21,6 @@ export function useJobsStatistics(initialPeriodKey: PeriodKeys) {
     },
     fetchPolicy: "no-cache",
     onCompleted(result) {
-      console.log(result);
       setAllJobCount(result.getJobsStatistics.totalCount);
       setNewPostedCount(result.getJobsStatistics.newPostedCount);
       setActiveCount(result.getJobsStatistics.activeCount);

--- a/src/schemas/magazine/edit.ts
+++ b/src/schemas/magazine/edit.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const magazineItemSchema = z.object({
+  articleId: z.coerce.number().min(1),
   title: z.string().trim().nonempty("タイトルを入力してください"),
   description: z.string().trim().nonempty("説明を入力してください"),
   category: z.string().trim().nonempty("カテゴリを入力してください"),
@@ -10,7 +11,7 @@ const magazineItemSchema = z.object({
       file == null || (file instanceof File && file.type.startsWith("image/"))
     );
   }, "画像ファイルを選択してください"),
-  url: z.string().trim().url("URLを入力してください"),
+  articleUrl: z.string().trim().url("URLを入力してください"),
 });
 
 export const magazineEditFormSchema = z.object({

--- a/src/server/graphql/magazine/mutations.ts
+++ b/src/server/graphql/magazine/mutations.ts
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+export const UPDATE_MAGAZINE = gql`
+  mutation UpdateMagazine($input: UpdateMagazinesInput!) {
+    updateMagazines(input: $input) {
+      id
+      title
+      description
+      category
+      thumbnailUrl
+      articleUrl
+    }
+  }
+`;

--- a/src/server/graphql/magazine/query.ts
+++ b/src/server/graphql/magazine/query.ts
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+export const GET_MAGAZINE = gql`
+  query GetMagazine {
+    magazines {
+      id
+      title
+      description
+      category
+      thumbnailUrl
+      articleUrl
+    }
+  }
+`;

--- a/src/utils/frontend/file.ts
+++ b/src/utils/frontend/file.ts
@@ -9,3 +9,14 @@ export const handleFileChange = (
     callback({ file: null, files: [] });
   }
 };
+
+export const blobToDataUrl = (blob: Blob) => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(blob);
+    reader.onload = () => {
+      resolve(reader.result as string);
+    };
+    reader.onerror = (error) => reject(error);
+  });
+};


### PR DESCRIPTION
[Magazine更新APIのリクエストにサムネイルを含められるようにした](https://github.com/dotbeat/myturn-api/pull/132)ことに合わせ、ファイル選択欄で選択した画像が実際にアップロードされるようにしました。
また、選択している画像または保存済みのサムネイルが、以下スクリーンショットのように表示されます。

![スクリーンショット 2025-05-03 0 35 06](https://github.com/user-attachments/assets/6b4546bc-e649-44d3-8fc0-06ee796f405b)