### PR TITLE
求職者管理画面にて学科系統を表示する

### DIFF
--- a/src/components/user/UserFilterForm.tsx
+++ b/src/components/user/UserFilterForm.tsx
@@ -5,7 +5,7 @@ import {
   availableDaysPerWeeksAndEmpty,
   availableDurationMonthsAndEmpty,
   availableHoursPerWeeksAndEmpty,
-  departmentsAndEmpty,
+  schoolDepartmentsAndEmpty,
   gendersAndEmpty,
   schoolGradesAndEmpty,
 } from "@/const/user";
@@ -62,7 +62,7 @@ export default function UserFilterForm({ isLoading }: { isLoading: boolean }) {
         <FilterItem label="学科系統">
           <SelectMini
             name="department"
-            items={departmentsAndEmpty("")}
+            items={schoolDepartmentsAndEmpty("")}
             className="w-28"
           />
         </FilterItem>

--- a/src/components/user/UserList.tsx
+++ b/src/components/user/UserList.tsx
@@ -5,7 +5,7 @@ import {
   availableDaysPerWeeks,
   availableDurationMonths,
   availableHoursPerWeeks,
-  departments,
+  schoolDepartments,
   schoolGrades,
 } from "@/const/user";
 import Avatar from "@/components/common/Avatar";
@@ -68,7 +68,7 @@ export default function UserList({
       ) : (
         "—"
       ),
-    department: getSelectItem(departments, item.department)?.label ?? "—",
+    department: getSelectItem(schoolDepartments, item.department)?.label ?? "—",
     grade: getSelectItem(schoolGrades, item.grade)?.label ?? "—",
     createdAt: new Date(item.createdAt).toLocaleDateString("ja"),
     deletedAt: item.deletedAt

--- a/src/const/user.ts
+++ b/src/const/user.ts
@@ -10,21 +10,27 @@ export function gendersAndEmpty(emptyLabel: string): SelectItem[] {
 }
 
 // 学科系統
-export const departments: SelectItem[] = [
-  { value: "A", label: "人文科学" },
-  { value: "C", label: "社会科学" },
-  { value: "E", label: "理学" },
-  { value: "G", label: "工学" },
-  { value: "K", label: "農学" },
-  { value: "M", label: "保健" },
-  { value: "P", label: "商船" },
-  { value: "Q", label: "家政" },
-  { value: "S", label: "教育" },
-  { value: "V", label: "芸術" },
-  { value: "X", label: "その他" },
+export const schoolDepartments: SelectItem[] = [
+  { value: "LAW", label: "法律・政治学系" },
+  { value: "ECO", label: "経済・経営・商学学系" },
+  { value: "SOC", label: "社会・メディア学系" },
+  { value: "INT", label: "国際関係学系" },
+  { value: "LIT", label: "文学・人文・心理学系" },
+  { value: "LNG", label: "外国語学系" },
+  { value: "EDU", label: "教育・福祉学系" },
+  { value: "HOM", label: "家政・生活学系" },
+  { value: "ART", label: "芸術・表現系" },
+  { value: "SPO", label: "健康・スポーツ系" },
+  { value: "GEN", label: "教養・総合系" },
+  { value: "SCI", label: "理・工学系" },
+  { value: "AGR", label: "農・獣・畜産・水産系" },
+  { value: "MED", label: "医・歯・薬学系" },
+  { value: "NUR", label: "看護・保健・衛生系" },
+  { value: "OTH", label: "その他文系" },
+  { value: "OTS", label: "その他理系" },
 ];
-export function departmentsAndEmpty(emptyLabel: string): SelectItem[] {
-  return [{ value: "", label: emptyLabel }, ...departments];
+export function schoolDepartmentsAndEmpty(emptyLabel: string): SelectItem[] {
+  return [{ value: "", label: emptyLabel }, ...schoolDepartments];
 }
 
 // 学年
@@ -33,18 +39,28 @@ export const schoolGrades: SelectItem[] = [
   { value: "SECOND_YEAR", label: "2年生" },
   { value: "THIRD_YEAR", label: "3年生" },
   { value: "FOURTH_YEAR", label: "4年生" },
+  { value: "FIFTH_YEAR", label: "5年生" },
+  { value: "SIXTH_YEAR", label: "6年生" },
+  { value: "MASTER_FIRST_YEAR", label: "修士1年生" },
+  { value: "MASTER_SECOND_YEAR", label: "修士2年生" },
+  { value: "DOCTOR_FIRST_YEAR", label: "博士1年生" },
+  { value: "DOCTOR_SECOND_YEAR", label: "博士2年生" },
+  { value: "DOCTOR_THIRD_YEAR", label: "博士3年生" },
+  { value: "GRADUATED", label: "既卒" },
+  { value: "OTHER", label: "その他" },
 ];
 export function schoolGradesAndEmpty(emptyLabel: string): SelectItem[] {
   return [{ value: "", label: emptyLabel }, ...schoolGrades];
 }
 
 // 週の勤務可能日数
-export const availableDaysPerWeeks: SelectItem<number>[] = (() => {
-  return new Array(7).fill(0).map((v, i) => ({
-    value: i + 1,
-    label: `週${i + 1}日`,
-  }));
-})();
+export const availableDaysPerWeeks: SelectItem<number>[] = [
+  { value: 1, label: "週1日" },
+  { value: 2, label: "週2日" },
+  { value: 3, label: "週3日" },
+  { value: 4, label: "週4日" },
+  { value: 5, label: "週5日以上" },
+];
 export function availableDaysPerWeeksAndEmpty(
   emptyLabel: string,
 ): SelectItem<number>[] {
@@ -66,19 +82,18 @@ export function availableHoursPerWeeksAndEmpty(
 
 // 継続可能期間
 export const availableDurationMonths: SelectItem<number>[] = [
-  { value: 1, label: "1ヶ月以上" },
-  { value: 2, label: "2ヶ月以上" },
-  { value: 3, label: "3ヶ月以上" },
-  { value: 4, label: "4ヶ月以上" },
-  { value: 5, label: "5ヶ月以上" },
-  { value: 6, label: "6ヶ月以上" },
-  { value: 9, label: "9ヶ月以上" },
-  { value: 12, label: "1年以上" },
-  { value: 18, label: "1年半以上" },
-  { value: 24, label: "2年以上" },
-  { value: 30, label: "2年半以上" },
-  { value: 36, label: "3年以上" },
-  { value: 42, label: "3年半以上" },
+  { value: 1, label: "1か月" },
+  { value: 2, label: "2か月" },
+  { value: 3, label: "3か月" },
+  { value: 4, label: "4か月" },
+  { value: 5, label: "5か月" },
+  { value: 6, label: "6か月" },
+  { value: 7, label: "7か月" },
+  { value: 8, label: "8か月" },
+  { value: 9, label: "9か月" },
+  { value: 10, label: "10か月" },
+  { value: 11, label: "11か月" },
+  { value: 12, label: "12か月以上" },
 ];
 export function availableDurationMonthsAndEmpty(
   emptyLabel: string,


### PR DESCRIPTION
> adminの求職者管理ページですが、学科系統が反映されてなさそうですね！

[櫻井さんによる指摘](https://dotbeat.slack.com/archives/C086W4PS4F3/p1747380994863659)を修正しました。

原因は学科系統リストなどいくつかの選択肢項目が管理側コードだけ古かったことです。
そのため、求職者側・企業側コードに合わせました。