### PR TITLE
業界の選択肢を企業側のものと同じに更新 / 同じ条件で検索した時1件も表示されなくなる不具合を修正

### DIFF
--- a/src/components/company/CompanyList.tsx
+++ b/src/components/company/CompanyList.tsx
@@ -18,7 +18,7 @@ export default function CompanyList({
     { property: "iconImageUrl", label: "ロゴ" },
     { property: "name", label: "企業名" },
     { property: "prefecture", label: "都道府県" },
-    { property: "industry", label: "業種" },
+    { property: "industry", label: "業界" },
     { property: "createdAt", label: "登録日" },
     { property: "deletedAt", label: "退会日" },
     { property: "jobCount", label: "掲載求人" },

--- a/src/const/job.ts
+++ b/src/const/job.ts
@@ -38,7 +38,12 @@ export const industries: SelectItem[] = [
   "交通/インフラ",
   "サービス",
   "飲食",
-  "旅行",
+  "旅行/レジャー",
+  "アパレル/ファッション",
+  "スポーツ",
+  "ゲーム",
+  "ホテル/ブライダル",
+  "NPO",
 ].map((period) => ({
   value: period,
   label: period,

--- a/src/hooks/useApplicants.ts
+++ b/src/hooks/useApplicants.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import { ApplicantFilterFormData } from "@/schemas/applicant/filter";
 import { SEARCH_ENTRIES } from "@/server/graphql/entry/queries";
 import { ApplicantItem } from "@/types/applicant";
+import { isSameObject } from "@/utils/shared/object";
 
 export function useApplicants(
   initialInput: ApplicantFilterFormData,
@@ -26,9 +27,11 @@ export function useApplicants(
   });
 
   // 再リクエストする
-  const refetchApplicants = async (input: ApplicantFilterFormData) => {
-    setApplicants([]);
-    setInput(input);
+  const refetchApplicants = async (newInput: ApplicantFilterFormData) => {
+    if (!isSameObject(input, newInput)) {
+      setApplicants([]);
+      setInput(newInput);
+    }
   };
 
   return {

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import { CompanyFilterFormData } from "@/schemas/company/filter";
 import { SEARCH_COMPANY } from "@/server/graphql/company/queries";
 import { CompanyItem } from "@/types/company";
+import { isSameObject } from "@/utils/shared/object";
 
 export function useCompanies(
   initialInput: CompanyFilterFormData,
@@ -26,9 +27,11 @@ export function useCompanies(
   });
 
   // 再リクエストする
-  const refetchCompanies = async (input: CompanyFilterFormData) => {
-    setCompanies([]);
-    setInput(input);
+  const refetchCompanies = async (newInput: CompanyFilterFormData) => {
+    if (!isSameObject(input, newInput)) {
+      setCompanies([]);
+      setInput(newInput);
+    }
   };
 
   return {

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import { JobFilterFormData } from "@/schemas/job/filter";
 import { SEARCH_JOB } from "@/server/graphql/job/queries";
 import { JobItem } from "@/types/job";
+import { isSameObject } from "@/utils/shared/object";
 
 export function useJobs(
   initialInput: JobFilterFormData,
@@ -26,9 +27,11 @@ export function useJobs(
   });
 
   // 再リクエストする
-  const refetchJobs = async (input: JobFilterFormData) => {
-    setJobs([]);
-    setInput(input);
+  const refetchJobs = async (newInput: JobFilterFormData) => {
+    if (!isSameObject(input, newInput)) {
+      setJobs([]);
+      setInput(newInput);
+    }
   };
 
   return {

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import { UserFilterFormData } from "@/schemas/user/filter";
 import { SEARCH_USERS } from "@/server/graphql/user/queries";
 import { UserItem } from "@/types/user";
+import { isSameObject } from "@/utils/shared/object";
 
 export function useUsers(
   initialInput: UserFilterFormData,
@@ -26,9 +27,11 @@ export function useUsers(
   });
 
   // 再リクエストする
-  const refetchUsers = async (input: UserFilterFormData) => {
-    setUsers([]);
-    setInput(input);
+  const refetchUsers = async (newInput: UserFilterFormData) => {
+    if (!isSameObject(input, newInput)) {
+      setUsers([]);
+      setInput(newInput);
+    }
   };
 
   return {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,26 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
 export function middleware(req: NextRequest) {
-    const basicAuth = req.headers.get('authorization');
-    const url = req.nextUrl;
+  const basicAuth = req.headers.get("authorization");
+  const url = req.nextUrl;
 
-    if (basicAuth) {
-        const authValue = basicAuth.split(' ')[1];
-        const [user, pwd] = atob(authValue).split(':');
+  if (basicAuth) {
+    const authValue = basicAuth.split(" ")[1];
+    const [user, pwd] = atob(authValue).split(":");
 
-        if (user === process.env.BASIC_AUTH_USER && pwd === process.env.BASIC_AUTH_PASSWORD) {
-            return NextResponse.next();
-        }
+    if (
+      user === process.env.BASIC_AUTH_USER &&
+      pwd === process.env.BASIC_AUTH_PASSWORD
+    ) {
+      return NextResponse.next();
     }
-    url.pathname = '/api/auth';
+  }
+  url.pathname = "/api/auth";
 
-    return NextResponse.rewrite(url);
+  return NextResponse.rewrite(url);
 }
 
 // すべてのルートに対して認証を適用
 export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ["/rgkefjnewjrgf"],
 };

--- a/src/utils/shared/object.ts
+++ b/src/utils/shared/object.ts
@@ -1,0 +1,14 @@
+export function isSameObject(
+  obj1: Record<string, any>,
+  obj2: Record<string, any>,
+) {
+  if (Object.keys(obj1).length !== Object.keys({ ...obj1, ...obj2 }).length) {
+    return false;
+  }
+  for (const key in obj1) {
+    if (obj1[key] !== obj2[key]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
私自身で気づいて[Slackにコメントした不具合](https://dotbeat.slack.com/archives/C086W4PS4F3/p1747450653482979?thread_ts=1747380994.863659&cid=C086W4PS4F3)を修正しました。

> 該当部分の修正は確認できましたが、企業アカウント管理画面の「業種」列も表示されないケースがあることに気付きましたので、併せて修正します。

これは、依存する業界の選択肢項目が企業側のコードと異なっていたためですので、同じにしました。

---

木曜日のミーティングで話した、同じ条件で検索した時に1件も表示されなくなる不具合についても対応しました。
そもそも同じ条件の場合検索処理を実行しないように修正しました。