### PR TITLE
ページ切り替え時に絞り込み条件を保持する

### DIFF
--- a/src/hooks/useApplicants.ts
+++ b/src/hooks/useApplicants.ts
@@ -3,14 +3,12 @@ import { useQuery } from "@apollo/client";
 import { ApplicantFilterFormData } from "@/schemas/applicant/filter";
 import { SEARCH_ENTRIES } from "@/server/graphql/entry/queries";
 import { ApplicantItem } from "@/types/applicant";
-import { isSameObject } from "@/utils/shared/object";
 
 export function useApplicants(
-  initialInput: ApplicantFilterFormData,
+  input: ApplicantFilterFormData,
   page: number,
   limit: number,
 ) {
-  const [input, setInput] = useState<ApplicantFilterFormData>(initialInput);
   const [applicants, setApplicants] = useState<ApplicantItem[]>([]);
   const [totalCount, setTotalCount] = useState(0); // 検索結果数(全ページ)
   const [totalPages, setTotalPages] = useState(0); // 一覧表のページ数
@@ -26,19 +24,10 @@ export function useApplicants(
     },
   });
 
-  // 再リクエストする
-  const refetchApplicants = async (newInput: ApplicantFilterFormData) => {
-    if (!isSameObject(input, newInput)) {
-      setApplicants([]);
-      setInput(newInput);
-    }
-  };
-
   return {
     applicants,
     totalCount,
     totalPages,
     loading,
-    refetchApplicants,
   };
 }

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -3,14 +3,12 @@ import { useQuery } from "@apollo/client";
 import { CompanyFilterFormData } from "@/schemas/company/filter";
 import { SEARCH_COMPANY } from "@/server/graphql/company/queries";
 import { CompanyItem } from "@/types/company";
-import { isSameObject } from "@/utils/shared/object";
 
 export function useCompanies(
-  initialInput: CompanyFilterFormData,
+  input: CompanyFilterFormData,
   page: number,
   limit: number,
 ) {
-  const [input, setInput] = useState(initialInput);
   const [companies, setCompanies] = useState<CompanyItem[]>([]);
   const [totalCount, setTotalCount] = useState(0); // 検索結果数(全ページ)
   const [totalPages, setTotalPages] = useState(0); // 一覧表のページ数
@@ -26,19 +24,10 @@ export function useCompanies(
     },
   });
 
-  // 再リクエストする
-  const refetchCompanies = async (newInput: CompanyFilterFormData) => {
-    if (!isSameObject(input, newInput)) {
-      setCompanies([]);
-      setInput(newInput);
-    }
-  };
-
   return {
     companies,
     totalCount,
     totalPages,
     loading,
-    refetchCompanies,
   };
 }

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -3,14 +3,8 @@ import { useQuery } from "@apollo/client";
 import { JobFilterFormData } from "@/schemas/job/filter";
 import { SEARCH_JOB } from "@/server/graphql/job/queries";
 import { JobItem } from "@/types/job";
-import { isSameObject } from "@/utils/shared/object";
 
-export function useJobs(
-  initialInput: JobFilterFormData,
-  page: number,
-  limit: number,
-) {
-  const [input, setInput] = useState(initialInput);
+export function useJobs(input: JobFilterFormData, page: number, limit: number) {
   const [jobs, setJobs] = useState<JobItem[]>([]);
   const [totalCount, setTotalCount] = useState(0); // 検索結果数(全ページ)
   const [totalPages, setTotalPages] = useState(0); // 一覧表のページ数
@@ -26,19 +20,10 @@ export function useJobs(
     },
   });
 
-  // 再リクエストする
-  const refetchJobs = async (newInput: JobFilterFormData) => {
-    if (!isSameObject(input, newInput)) {
-      setJobs([]);
-      setInput(newInput);
-    }
-  };
-
   return {
     jobs,
     totalCount,
     totalPages,
     loading,
-    refetchJobs,
   };
 }

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -3,14 +3,12 @@ import { useQuery } from "@apollo/client";
 import { UserFilterFormData } from "@/schemas/user/filter";
 import { SEARCH_USERS } from "@/server/graphql/user/queries";
 import { UserItem } from "@/types/user";
-import { isSameObject } from "@/utils/shared/object";
 
 export function useUsers(
-  initialInput: UserFilterFormData,
+  input: UserFilterFormData,
   page: number,
   limit: number,
 ) {
-  const [input, setInput] = useState<UserFilterFormData>(initialInput);
   const [users, setUsers] = useState<UserItem[]>([]);
   const [totalCount, setTotalCount] = useState(0); // 検索結果数(全ページ)
   const [totalPages, setTotalPages] = useState(0); // 一覧表のページ数
@@ -26,19 +24,10 @@ export function useUsers(
     },
   });
 
-  // 再リクエストする
-  const refetchUsers = async (newInput: UserFilterFormData) => {
-    if (!isSameObject(input, newInput)) {
-      setUsers([]);
-      setInput(newInput);
-    }
-  };
-
   return {
     users,
     totalCount,
     totalPages,
     loading,
-    refetchUsers,
   };
 }

--- a/src/utils/frontend/form.ts
+++ b/src/utils/frontend/form.ts
@@ -1,0 +1,56 @@
+// input : { q: "hoge", date: new Date("2025-05-26"), page: 2 }
+// output: ?q=hoge&date=2025-05-26&page=2
+export function convertFormDataToUrlParams(
+  data: Record<string, string | number | Date | null | undefined>,
+): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  Object.entries(data).forEach(([key, value]) => {
+    if (value instanceof Date) {
+      if (!Number.isNaN(value.getTime())) {
+        searchParams.set(key, value.toISOString().slice(0, 10));
+      }
+    } else if (
+      typeof value === "string" ||
+      (typeof value === "number" && !Number.isNaN(value))
+    ) {
+      if (value) {
+        searchParams.set(key, String(value));
+      }
+    }
+  });
+  return searchParams;
+}
+
+export class ConvertUrlParamEntry {
+  private searchParams: URLSearchParams;
+
+  constructor(searchParams: URLSearchParams) {
+    this.searchParams = searchParams;
+  }
+
+  // searchParams: ?q=hoge
+  // input : "q"
+  // output: "hoge"
+  toString(paramKey: string, defaultValue = "") {
+    const paramValue = this.searchParams.get(paramKey);
+    return paramValue ?? defaultValue;
+  }
+  // searchParams: ?page=2
+  // input : "page"
+  // output: 2
+  toNumber(paramKey: string, defaultValue = 0) {
+    const paramValue = this.searchParams.get(paramKey);
+    return parseInt(paramValue ?? String(defaultValue), 10);
+  }
+
+  // searchParams: ?date=2025-05-26
+  // input : "date"
+  // output: new Date("2025-05-26")
+  toDate(paramKey: string, defaultValue: string | null = null) {
+    const paramValue = this.searchParams.get(paramKey);
+    const valueAsDate = new Date(paramValue ?? "");
+    return !Number.isNaN(valueAsDate.getTime())
+      ? valueAsDate.toISOString().slice(0, 10)
+      : defaultValue;
+  }
+}


### PR DESCRIPTION
求職者・企業・求人・応募者一覧画面について修正。
絞り込み条件はURLパラメータで保持するように仕様変更しました。（例：/jobs?title=大量&prefecture=東京都&openDateStart=2025-05-26&page=2）