### PR TITLE
(管理側) 応募者一覧表にて1回目・2回目の面談日を表示する

### DIFF
--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -25,6 +25,8 @@ export default function ApplicantList({
     { property: "entryDate", label: "応募日" },
     { property: "status", label: "ステータス" },
     { property: "hasAcceptReport", label: "内定報告" },
+    { property: "interviewScheduledAt", label: "1回目面談日" },
+    { property: "secondInterviewScheduledAt", label: "2回目面談日" },
     { property: "joinDate", label: "入社予定日" },
   ] as const satisfies TableColumn<(keyof ApplicantItem)[number]>[];
 
@@ -86,6 +88,12 @@ export default function ApplicantList({
     entryDate: new Date(item.createdAt)?.toLocaleDateString("ja") ?? "—",
     status: applyStatusIndex[item.status]?.label ?? "—",
     hasAcceptReport: item.joinDate ? "あり" : "なし",
+    interviewScheduledAt: item.interviewScheduledAt
+      ? new Date(item.interviewScheduledAt)?.toLocaleDateString("ja")
+      : "—",
+    secondInterviewScheduledAt: item.secondInterviewScheduledAt
+      ? new Date(item.secondInterviewScheduledAt)?.toLocaleDateString("ja")
+      : "—",
     joinDate: item.joinDate
       ? new Date(item.joinDate)?.toLocaleDateString("ja")
       : "—",

--- a/src/graphql-client.ts
+++ b/src/graphql-client.ts
@@ -2455,7 +2455,7 @@ export type SearchEntriesQueryVariables = Exact<{
 }>;
 
 
-export type SearchEntriesQuery = { __typename?: 'Query', searchEntries: { __typename?: 'EntrySearchResultType', limit: number, page: number, totalCount: number, totalPages: number, hasNextPage: boolean, hasPreviousPage: boolean, items: Array<{ __typename?: 'EntryWithDetailsType', id: number, jobId: number, userId: number, createdAt: any, updatedAt: any, status: string, joinDate?: any | null, job: { __typename?: 'JobWithCompanyType', id: number, title: string, jobType: string, industry: string, company: { __typename?: 'CompanyType', id: number, name: string, deletedAt?: any | null } }, user: { __typename?: 'UserType', id: number, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, deletedAt?: any | null } }> } };
+export type SearchEntriesQuery = { __typename?: 'Query', searchEntries: { __typename?: 'EntrySearchResultType', limit: number, page: number, totalCount: number, totalPages: number, hasNextPage: boolean, hasPreviousPage: boolean, items: Array<{ __typename?: 'EntryWithDetailsType', id: number, jobId: number, userId: number, createdAt: any, updatedAt: any, status: string, joinDate?: any | null, interviewScheduledAt?: any | null, secondInterviewScheduledAt?: any | null, job: { __typename?: 'JobWithCompanyType', id: number, title: string, jobType: string, industry: string, company: { __typename?: 'CompanyType', id: number, name: string, deletedAt?: any | null } }, user: { __typename?: 'UserType', id: number, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, deletedAt?: any | null } }> } };
 
 export type GetEntriesStatisticsQueryVariables = Exact<{
   input: GetEntriesStatisticsInput;
@@ -2799,6 +2799,8 @@ export const SearchEntriesDocument = gql`
       updatedAt
       status
       joinDate
+      interviewScheduledAt
+      secondInterviewScheduledAt
       job {
         id
         title

--- a/src/server/graphql/entry/queries.ts
+++ b/src/server/graphql/entry/queries.ts
@@ -11,6 +11,8 @@ export const SEARCH_ENTRIES = gql`
         updatedAt
         status
         joinDate
+        interviewScheduledAt
+        secondInterviewScheduledAt
         job {
           id
           title

--- a/src/types/applicant.ts
+++ b/src/types/applicant.ts
@@ -28,4 +28,6 @@ export type ApplicantItem = {
   createdAt: string;
   status: ApplyStatus;
   joinDate: string;
+  interviewScheduledAt: string | null;
+  secondInterviewScheduledAt: string | null;
 };


### PR DESCRIPTION
Slackでの会話：https://dotbeat.slack.com/archives/C086W4PS4F3/p1764145813297439
Issue：https://github.com/dotbeat/myturn-admin/issues/70

内定報告列の右に表示します。

<img width="1677" height="641" alt="スクリーンショット 2025-11-27 21 26 16" src="https://github.com/user-attachments/assets/8a6b2cf7-ca11-4642-a318-449e3440c142" />
